### PR TITLE
Update ProductOffering.xsd

### DIFF
--- a/CUFX/Schemas/ProductOffering.xsd
+++ b/CUFX/Schemas/ProductOffering.xsd
@@ -280,6 +280,14 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="aprRate" type="xs:decimal" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						The interest rate calculated as an annual percentage rate.
+						As calculated by the FI.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 


### PR DESCRIPTION
Since APR calculation may be unique to the FI, providing an optional pre-calculated APR allows this information to be easily available for a client application without needing to duplicate the FI's APR calculation and significant digits.